### PR TITLE
36 add tests for the whole api so far

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ package-lock.json
 
 # Environment
 .env
+
+# Tests
+tests/reports/

--- a/app.js
+++ b/app.js
@@ -1,17 +1,9 @@
-
 const express = require('express');
-const router = express.Router();
 const dotenv = require("dotenv");
 const dotenvExpand = require("dotenv-expand");
 dotenvExpand.expand(dotenv.config());
 const app = express();
-const port = process.env.PORT;
 
-const mongoose = require('mongoose');
-mongoose.connect(process.env.DB_CONNECTION)
-const db = mongoose.connection;
-db.on('error', (error) => console.error(error));
-db.once('open', () => console.log("Connected to DataBase"));
 
 const bodyParser = require('body-parser');
 app.use(bodyParser.json());
@@ -30,8 +22,4 @@ app.use('/post', posts_routes);
 const comments_routes = require('./routes/comments_routes');
 app.use('/comment', comments_routes);	
 
-app.listen(port, () => {
-    console.log(`Example app listening at http://localhost:${port}`);
-});
-
-
+module.exports = app;

--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
 {
-  "name": "ex-1",
+  "name": "ex",
   "version": "1.0.0",
-  "description": "First Advenced Web Apps Cours exercise",
-  "main": "app.js",
+  "description": "Advanced Web Apps Course Exercise",
+  "main": "server.js",
   "scripts": {
-    "start": "node app.js",
-    "dev": "nodemon app.js",
+    "start": "node server.js",
+    "dev": "nodemon server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/taljacob2/colman-advanced-web-apps-ex-1.git"
+    "url": "git+https://github.com/taljacob2/colman-advanced-web-apps.git"
   },
   "author": "Mevorah Berrebi & Tal Jacob",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/taljacob2/colman-advanced-web-apps-ex-1/issues"
+    "url": "https://github.com/taljacob2/colman-advanced-web-apps/issues"
   },
-  "homepage": "https://github.com/taljacob2/colman-advanced-web-apps-ex-1#readme",
+  "homepage": "https://github.com/taljacob2/colman-advanced-web-apps#readme",
   "dependencies": {
     "body-parser": "^1.20.3",
     "dotenv": "^16.4.5",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "cross-env NODE_ENV=test jest --config=tests/jest.config.js --collectCoverage --ci --watchAll=false --detectOpenHandles --forceExit"
   },
   "repository": {
     "type": "git",
@@ -20,10 +20,14 @@
   "homepage": "https://github.com/taljacob2/colman-advanced-web-apps#readme",
   "dependencies": {
     "body-parser": "^1.20.3",
+    "cross-env": "^7.0.3",
     "dotenv": "^16.4.5",
     "dotenv-expand": "^12.0.1",
     "express": "^4.21.1",
-    "mongoose": "^8.8.2"
+    "jest": "^29.7.0",
+    "jest-junit": "^16.0.0",
+    "mongoose": "^8.8.2",
+    "supertest": "^7.0.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.7"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "cross-env NODE_ENV=test jest --config=tests/jest.config.js --collectCoverage --ci --watchAll=false --detectOpenHandles --forceExit"
+    "test": "cross-env NODE_ENV=test jest --config=tests/jest.config.js --collectCoverage --ci --watchAll=false --runInBand --detectOpenHandles --forceExit"
   },
   "repository": {
     "type": "git",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,13 @@
+const app = require('./app');
+const mongoose = require('mongoose');
+
+
+// Start app while verifying connection to the database.
+const port = process.env.PORT;
+app.listen(port, () => {    
+    mongoose.connect(process.env.DB_CONNECTION)
+    const db = mongoose.connection;
+    db.on('error', (error) => console.error(error));
+    db.once('open', () => console.log("Connected to DataBase"));
+    console.log(`Example app listening at http://localhost:${port}`);
+});

--- a/tests/__tests__/controllers/comments_controller.test.js
+++ b/tests/__tests__/controllers/comments_controller.test.js
@@ -256,7 +256,6 @@ describe('given unknown post when http request GET /comment/post/id', () => {
     });
 });
 
-
 describe('given existing post without any comments when http request GET /comment/post/id', () => {
     it('then should return empty list', async () => {
         const res = await request(app)
@@ -264,5 +263,22 @@ describe('given existing post without any comments when http request GET /commen
     
         expect(res.statusCode).toBe(200);
         expect(res.body).toEqual([]);
+    });
+});
+
+describe('given unknown comment when http request DELETE /comment/id', () => {
+    it('then should return 400 bad request http status', async () => {
+        const res = await request(app).delete(`/comment/UNKNOWN`);
+
+        expect(res.statusCode).toBe(400);
+    });
+});
+
+describe('given existing comment when http request DELETE /comment/id', () => {
+    it('then should return 200 success http status', async () => {
+        const res = await request(app)
+            .delete(`/comment/${existingComment._id}`);
+
+        expect(res.statusCode).toBe(200);
     });
 });

--- a/tests/__tests__/controllers/comments_controller.test.js
+++ b/tests/__tests__/controllers/comments_controller.test.js
@@ -1,0 +1,186 @@
+const request = require('supertest');
+const app = require('../../../app');
+
+let existingPost = null;
+let existingComment = null;
+
+describe('given db empty of comments when http request GET /comment', () => {
+    it('then should return empty list', async () => {
+        const res = await request(app).get('/comment');
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toStrictEqual([]);
+    });
+});
+
+/**
+ * Already tested in posts_controller.
+ * We need this just for initializing `existingPost`.
+ */
+describe('when http request POST /post', () => {
+    it('then should add post to the db', async () => {
+        const body = {
+            "sender": "USERNAME",
+            "title": "POST TITLE",
+            "content": "POST CONTENT"
+        };
+        const res = await request(app).post('/post')
+            .send(body);
+        const resBody = res.body;
+        existingPost = { ...resBody };
+        delete resBody._id;
+
+        expect(res.statusCode).toBe(201);
+        expect(resBody).toEqual(body);
+    });
+});
+
+describe('when http request POST /comment to an unknown post', () => {
+    it('then should return 400 bad request http status', async () => {
+        const body = {
+            "postId": "UNKNOWN",
+            "sender": "USERNAME",
+            "content": "COMMENT CONTENT"
+        };
+        const res = await request(app).post('/comment')
+            .send(body);
+
+        expect(res.statusCode).toBe(400);
+    });
+});
+
+describe('when http request POST /comment to an existing post without required sender field', () => {
+    it('then should return 400 bad request http status', async () => {
+        const body = {
+            "postId": `${existingPost._id}`,
+            "content": "COMMENT CONTENT"
+        };
+        const res = await request(app).post('/comment')
+            .send(body);
+
+        expect(res.statusCode).toBe(400);
+    });
+});
+
+describe('when http request POST /comment without required postId field', () => {
+    it('then should return 404 not found http status', async () => {
+        const body = {
+            "sender": "USERNAME",
+            "content": "COMMENT CONTENT"
+        };
+        const res = await request(app).post('/comment')
+            .send(body);
+
+        expect(res.statusCode).toBe(404);
+    });
+});
+
+describe('when http request POST /comment  to an existing post', () => {
+    it('then should add comment to the db', async () => {
+        const body = {
+            "postId": `${existingPost._id}`,
+            "sender": "USERNAME",
+            "content": "POST CONTENT"
+        };
+        const res = await request(app).post('/comment')
+            .send(body);
+        const resBody = res.body;
+        existingComment = { ...resBody };
+        delete resBody._id;
+        delete resBody.createdAt;
+        delete resBody.updatedAt;
+
+        expect(res.statusCode).toBe(201);
+        expect(resBody).toEqual(body);
+    });
+});
+
+describe('given db initialized with comments when http request GET /comment', () => {
+    it('then should return all coments in the db', async () => {
+        const res = await request(app).get('/comment');
+        expect(res.statusCode).toBe(200);
+        expect(res.statusCode).not.toEqual([]);
+    });
+});
+
+describe('when http request PUT /comment/id of unknown post', () => {
+    it('then should return 201 created http status', async () => {
+        const body = {
+            "postId": "UNKNOWN",
+            "sender": "UPDATED USERNAME",
+            "content": "UPDATED COMMENT CONTENT"
+        };
+        const res = await request(app).put(`/comment/${existingComment._id}`)
+            .send(body);
+        const resBody = res.body;
+        delete resBody._id;
+        delete resBody.createdAt;
+        delete resBody.updatedAt;
+
+        expect(res.statusCode).toBe(201);
+        expect(resBody.postId).toEqual(existingPost._id);
+    });
+});
+
+describe('when http request PUT /comment/id of unknown comment', () => {
+    it('then should return 400 bad request http status', async () => {
+        const body = {
+            "postId": `${existingPost._id}`,
+            "sender": "UPDATED USERNAME",
+            "content": "UPDATED COMMENT CONTENT"
+        };
+        const res = await request(app).put(`/comment/UNKNOWN`)
+            .send(body);
+
+        expect(res.statusCode).toBe(400);
+    });
+});
+
+describe('when http request PUT /comment/id without required postId field', () => {
+    it('then should return 201 created http status', async () => {
+        const body = {
+            "sender": "UPDATED USERNAME",
+            "content": "UPDATED COMMENT CONTENT"
+        };
+        const res = await request(app).put(`/comment/${existingComment._id}`)
+            .send(body);
+        const resBody = res.body;
+        delete resBody._id;
+        delete resBody.createdAt;
+        delete resBody.updatedAt;
+
+        expect(res.statusCode).toBe(201);
+        expect(resBody.postId).toEqual(existingPost._id);
+    });
+});
+
+describe('when http request PUT /comment/id without required sender field', () => {
+    it('then should return 400 bad request http status', async () => {
+        const body = {
+            "postId": `${existingPost._id}`,
+            "content": "UPDATED COMMENT CONTENT"
+        };
+        const res = await request(app).put(`/comment/${existingComment._id}`)
+            .send(body);
+
+        expect(res.statusCode).toBe(400);
+    });
+});
+
+describe('when http request PUT /comment/id of existing post and comment', () => {
+    it('then should update comment in the db', async () => {
+        const body = {
+            "postId": `${existingPost._id}`,
+            "sender": "UPDATED USERNAME",
+            "content": "UPDATED COMMENT CONTENT"
+        };
+        const res = await request(app).put(`/comment/${existingComment._id}`)
+            .send(body);
+        const resBody = res.body;
+        delete resBody._id;
+        delete resBody.createdAt;
+        delete resBody.updatedAt;
+
+        expect(res.statusCode).toBe(201);
+        expect(resBody).toEqual(body);
+    });
+});

--- a/tests/__tests__/controllers/comments_controller.test.js
+++ b/tests/__tests__/controllers/comments_controller.test.js
@@ -19,18 +19,14 @@ describe('given db empty of comments when http request GET /comment', () => {
 describe('when http request POST /post', () => {
     it('then should add post to the db', async () => {
         const body = {
-            "sender": "USERNAME",
-            "title": "POST TITLE",
-            "content": "POST CONTENT"
+            "sender": "USERNAME1",
+            "title": "POST1 TITLE",
+            "content": "POST1 CONTENT"
         };
         const res = await request(app).post('/post')
             .send(body);
         const resBody = res.body;
         existingPost = { ...resBody };
-        delete resBody._id;
-
-        expect(res.statusCode).toBe(201);
-        expect(resBody).toEqual(body);
     });
 });
 
@@ -38,8 +34,8 @@ describe('when http request POST /comment to an unknown post', () => {
     it('then should return 400 bad request http status', async () => {
         const body = {
             "postId": "UNKNOWN",
-            "sender": "USERNAME",
-            "content": "COMMENT CONTENT"
+            "sender": "USERNAME1",
+            "content": "COMMENT1 CONTENT"
         };
         const res = await request(app).post('/comment')
             .send(body);
@@ -52,7 +48,7 @@ describe('when http request POST /comment to an existing post without required s
     it('then should return 400 bad request http status', async () => {
         const body = {
             "postId": `${existingPost._id}`,
-            "content": "COMMENT CONTENT"
+            "content": "COMMENT1 CONTENT"
         };
         const res = await request(app).post('/comment')
             .send(body);
@@ -64,8 +60,8 @@ describe('when http request POST /comment to an existing post without required s
 describe('when http request POST /comment without required postId field', () => {
     it('then should return 404 not found http status', async () => {
         const body = {
-            "sender": "USERNAME",
-            "content": "COMMENT CONTENT"
+            "sender": "USERNAME1",
+            "content": "COMMENT1 CONTENT"
         };
         const res = await request(app).post('/comment')
             .send(body);
@@ -78,8 +74,8 @@ describe('when http request POST /comment  to an existing post', () => {
     it('then should add comment to the db', async () => {
         const body = {
             "postId": `${existingPost._id}`,
-            "sender": "USERNAME",
-            "content": "POST CONTENT"
+            "sender": "USERNAME1",
+            "content": "COMMENT1 CONTENT"
         };
         const res = await request(app).post('/comment')
             .send(body);
@@ -91,6 +87,38 @@ describe('when http request POST /comment  to an existing post', () => {
 
         expect(res.statusCode).toBe(201);
         expect(resBody).toEqual(body);
+    });
+});
+
+/**
+ * Already tested this.
+ * We need this just for initializing some more comments.
+ */
+describe('when http request POST /comment  to an existing post', () => {
+    it('then should add comment to the db', async () => {
+        // Comment 1
+        const body1 = {
+            "postId": `${existingPost._id}`,
+            "sender": "USERNAME1",
+            "content": "COMMENT1 CONTENT"
+        };
+        await request(app).post('/comment').send(body1);
+
+        // Comment 2
+        const body2 = {
+            "postId": `${existingPost._id}`,
+            "sender": "USERNAME2",
+            "content": "COMMENT2 CONTENT"
+        };
+        await request(app).post('/comment').send(body2);
+
+        // Comment 3
+        const body3 = {
+            "postId": `${existingPost._id}`,
+            "sender": "USERNAME3",
+            "content": "COMMENT3 CONTENT"
+        };
+        await request(app).post('/comment').send(body3);
     });
 });
 
@@ -182,5 +210,21 @@ describe('when http request PUT /comment/id of existing post and comment', () =>
 
         expect(res.statusCode).toBe(201);
         expect(resBody).toEqual(body);
+    });
+});
+
+describe('given existing post when http request GET /comment/post/id', () => {
+    it('then should return its comments only', async () => {
+        const res = await request(app).get(`/comment/post/${existingPost._id}`);
+        const resBody = res.body;
+        const postIds = resBody.map((comment) => comment.postId);
+
+        // Use filter and return array with unique values
+        const uniquePostIds = postIds.filter(
+            (e, i, self) => i === self.indexOf(e));
+
+        expect(res.statusCode).toBe(200);
+        expect(uniquePostIds.length).toBe(1);
+        expect(uniquePostIds[0]).toEqual(resBody[0].postId);
     });
 });

--- a/tests/__tests__/controllers/comments_controller.test.js
+++ b/tests/__tests__/controllers/comments_controller.test.js
@@ -153,11 +153,13 @@ describe('when http request PUT /comment/id of unknown post', () => {
         const res = await request(app).put(`/comment/${existingComment._id}`)
             .send(body);
         const resBody = res.body;
+
+        expect(res.statusCode).toBe(201);
+        expect(new Date(resBody.updatedAt).getMilliseconds())
+            .toBeGreaterThan(new Date(resBody.createdAt).getMilliseconds());
         delete resBody._id;
         delete resBody.createdAt;
         delete resBody.updatedAt;
-
-        expect(res.statusCode).toBe(201);
         expect(resBody.postId).toEqual(existingPost1._id);
     });
 });
@@ -185,11 +187,13 @@ describe('when http request PUT /comment/id without required postId field', () =
         const res = await request(app).put(`/comment/${existingComment._id}`)
             .send(body);
         const resBody = res.body;
+
+        expect(res.statusCode).toBe(201);
+        expect(new Date(resBody.updatedAt).getMilliseconds())
+            .toBeGreaterThan(new Date(resBody.createdAt).getMilliseconds());
         delete resBody._id;
         delete resBody.createdAt;
         delete resBody.updatedAt;
-
-        expect(res.statusCode).toBe(201);
         expect(resBody.postId).toEqual(existingPost1._id);
     });
 });
@@ -217,11 +221,13 @@ describe('when http request PUT /comment/id of existing post and comment', () =>
         const res = await request(app).put(`/comment/${existingComment._id}`)
             .send(body);
         const resBody = res.body;
-        delete resBody._id;
-        delete resBody.createdAt;
-        delete resBody.updatedAt;
 
         expect(res.statusCode).toBe(201);
+        expect(new Date(resBody.updatedAt).getMilliseconds())
+            .toBeGreaterThan(new Date(resBody.createdAt).getMilliseconds());
+        delete resBody._id;
+        delete resBody.createdAt;
+        delete resBody.updatedAt;    
         expect(resBody).toEqual(body);
     });
 });

--- a/tests/__tests__/controllers/posts_controller.test.js
+++ b/tests/__tests__/controllers/posts_controller.test.js
@@ -14,9 +14,9 @@ describe('given db empty of posts when http request GET /post', () => {
 describe('when http request POST /post', () => {
     it('then should add post to the db', async () => {
         const body = {
-            "sender": "USERNAME",
-            "title": "POST TITLE",
-            "content": "POST CONTENT"
+            "sender": "USERNAME1",
+            "title": "POST1 TITLE",
+            "content": "POST1 CONTENT"
         };
         const res = await request(app).post('/post')
             .send(body);
@@ -29,11 +29,43 @@ describe('when http request POST /post', () => {
     });
 });
 
+/**
+ * Already tested this.
+ * We need this just for initializing some more posts.
+ */
+describe('when http request POST /post', () => {
+    it('then should add posts to the db', async () => {
+        // Post 1
+        const body1 = {
+            "sender": "USERNAME1",
+            "title": "POST1 TITLE",
+            "content": "POST1 CONTENT"
+        };
+        await request(app).post('/post').send(body1);
+
+        // Post 2
+        const body2 = {
+            "sender": "USERNAME2",
+            "title": "POST2 TITLE",
+            "content": "POST2 CONTENT"
+        };
+        await request(app).post('/post').send(body2);
+
+        // Post 3
+        const body3 = {
+            "sender": "USERNAME3",
+            "title": "POST3 TITLE",
+            "content": "POST3 CONTENT"
+        };
+        await request(app).post('/post').send(body3);
+    });
+});
+
 describe('when http request POST /post without required sender field', () => {
     it('then should return 400 bad request http status', async () => {
         const body = {
-            "title": "POST TITLE",
-            "content": "POST CONTENT"
+            "title": "POST1 TITLE",
+            "content": "POST1 CONTENT"
         };
         const res = await request(app).post('/post')
             .send(body);
@@ -61,7 +93,7 @@ describe('given unknown username when http request GET /post?sender', () => {
 
 describe('given existing username when http request GET /post?sender', () => {
     it('then should return his posts only', async () => {
-        const res = await request(app).get('/post?sender=USERNAME');
+        const res = await request(app).get('/post?sender=USERNAME1');
         const resBody = res.body;
         const senderList = resBody.map((post) => post.sender);
 

--- a/tests/__tests__/controllers/posts_controller.test.js
+++ b/tests/__tests__/controllers/posts_controller.test.js
@@ -1,15 +1,28 @@
 const request = require('supertest');
 const app = require('../../../app');
 
+describe('given db empty of posts when http request GET /post', () => {
+    it('then should return empty list', async () => {
+        const res = await request(app).get('/post');
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toStrictEqual([]);
+    });
+});
+
 describe('given empty db when http request POST /post', () => {
     it('then should add posts to the db', async () => {
+        const body = {
+            "sender": "Tal",
+            "title": "Post 2",
+            "content": "HELLO 12345!!"
+        };
         const res = await request(app).post('/post')
-            .send({
-                "sender": "Tal",
-                "title": "Post 2",
-                "content": "HELLO 12345!!"
-            });
+            .send(body);
+        const resBody = res.body;
+        delete resBody._id;
+
         expect(res.statusCode).toBe(201);
+        expect(resBody).toEqual(body);
     });
 });
 
@@ -17,5 +30,6 @@ describe('given db initialized with posts when http request GET /post', () => {
     it('then should return all posts in the db', async () => {
         const res = await request(app).get('/post');
         expect(res.statusCode).toBe(200);
+        expect(res.statusCode).not.toEqual([]);
     });
 });

--- a/tests/__tests__/controllers/posts_controller.test.js
+++ b/tests/__tests__/controllers/posts_controller.test.js
@@ -1,7 +1,7 @@
 const request = require('supertest');
 const app = require('../../../app');
 
-let exitingPost = null;
+let existingPost = null;
 
 describe('given db empty of posts when http request GET /post', () => {
     it('then should return empty list', async () => {
@@ -21,7 +21,7 @@ describe('when http request POST /post', () => {
         const res = await request(app).post('/post')
             .send(body);
         const resBody = res.body;
-        exitingPost = { ...resBody };
+        existingPost = { ...resBody };
         delete resBody._id;
 
         expect(res.statusCode).toBe(201);
@@ -59,7 +59,7 @@ describe('given unknown username when http request GET /post?sender', () => {
     });
 });
 
-describe('given known username when http request GET /post?sender', () => {
+describe('given existing username when http request GET /post?sender', () => {
     it('then should return his posts only', async () => {
         const res = await request(app).get('/post?sender=USERNAME');
         const resBody = res.body;
@@ -96,7 +96,7 @@ describe('when http request PUT /post/id of existing post', () => {
             "title": "UPDATED POST TITLE",
             "content": "UPDATED POST CONTENT"
         };
-        const res = await request(app).put(`/post/${exitingPost._id}`)
+        const res = await request(app).put(`/post/${existingPost._id}`)
             .send(body);
         const resBody = res.body;
         delete resBody._id;
@@ -112,7 +112,7 @@ describe('when http request PUT /post/id of existing post but without required s
             "title": "UPDATED POST TITLE",
             "content": "UPDATED POST CONTENT"
         };
-        const res = await request(app).put(`/post/${exitingPost._id}`)
+        const res = await request(app).put(`/post/${existingPost._id}`)
             .send(body);
 
         expect(res.statusCode).toBe(400);

--- a/tests/__tests__/controllers/posts_controller.test.js
+++ b/tests/__tests__/controllers/posts_controller.test.js
@@ -1,6 +1,8 @@
 const request = require('supertest');
 const app = require('../../../app');
 
+let exitingPost = null;
+
 describe('given db empty of posts when http request GET /post', () => {
     it('then should return empty list', async () => {
         const res = await request(app).get('/post');
@@ -9,20 +11,34 @@ describe('given db empty of posts when http request GET /post', () => {
     });
 });
 
-describe('given empty db when http request POST /post', () => {
-    it('then should add posts to the db', async () => {
+describe('when http request POST /post', () => {
+    it('then should add post to the db', async () => {
         const body = {
-            "sender": "Tal",
-            "title": "Post 2",
-            "content": "HELLO 12345!!"
+            "sender": "USERNAME",
+            "title": "POST TITLE",
+            "content": "POST CONTENT"
         };
         const res = await request(app).post('/post')
             .send(body);
         const resBody = res.body;
+        exitingPost = { ...resBody };
         delete resBody._id;
 
         expect(res.statusCode).toBe(201);
         expect(resBody).toEqual(body);
+    });
+});
+
+describe('when http request POST /post without required sender field', () => {
+    it('then should return 400 bad request http status', async () => {
+        const body = {
+            "title": "POST TITLE",
+            "content": "POST CONTENT"
+        };
+        const res = await request(app).post('/post')
+            .send(body);
+
+        expect(res.statusCode).toBe(400);
     });
 });
 
@@ -31,5 +47,61 @@ describe('given db initialized with posts when http request GET /post', () => {
         const res = await request(app).get('/post');
         expect(res.statusCode).toBe(200);
         expect(res.statusCode).not.toEqual([]);
+    });
+});
+
+describe('given unknown username when http request GET /post?sender', () => {
+    it('then should return empty list', async () => {
+        const res = await request(app).get('/post?sender=UNKNOWN');
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual([]);
+    });
+});
+
+describe('given known username when http request GET /post?sender', () => {
+    it('then should return his posts only', async () => {
+        const res = await request(app).get('/post?sender=USERNAME');
+        const resBody = res.body;
+        const senderList = resBody.map((post) => post.sender);
+
+        // Use filter and return array with unique values
+        const uniqueSenderList = senderList.filter(
+            (e, i, self) => i === self.indexOf(e));
+
+        expect(res.statusCode).toBe(200);
+        expect(uniqueSenderList.length).toBe(1);
+        expect(uniqueSenderList[0]).toEqual(resBody[0].sender);
+    });
+});
+
+describe('when http request PUT /post/id of unknown post', () => {
+    it('then should return 400 bad request http status', async () => {
+        const body = {
+            "sender": "UPDATED USERNAME",
+            "title": "UPDATED POST TITLE",
+            "content": "UPDATED POST CONTENT"
+        };
+        const res = await request(app).put(`/post/UNKNOWN`)
+            .send(body);
+
+        expect(res.statusCode).toBe(400);
+    });
+});
+
+describe('when http request PUT /post/id of existing post', () => {
+    it('then should update post in the db', async () => {
+        const body = {
+            "sender": "UPDATED USERNAME",
+            "title": "UPDATED POST TITLE",
+            "content": "UPDATED POST CONTENT"
+        };
+        const res = await request(app).put(`/post/${exitingPost._id}`)
+            .send(body);
+        const resBody = res.body;
+        delete resBody._id;
+
+        expect(res.statusCode).toBe(201);
+        expect(resBody).toEqual(body);
     });
 });

--- a/tests/__tests__/controllers/posts_controller.test.js
+++ b/tests/__tests__/controllers/posts_controller.test.js
@@ -7,7 +7,7 @@ describe('given db empty of posts when http request GET /post', () => {
     it('then should return empty list', async () => {
         const res = await request(app).get('/post');
         expect(res.statusCode).toBe(200);
-        expect(res.body).toStrictEqual([]);
+        expect(res.body).toEqual([]);
     });
 });
 

--- a/tests/__tests__/controllers/posts_controller.test.js
+++ b/tests/__tests__/controllers/posts_controller.test.js
@@ -105,3 +105,16 @@ describe('when http request PUT /post/id of existing post', () => {
         expect(resBody).toEqual(body);
     });
 });
+
+describe('when http request PUT /post/id of existing post but without required sender field', () => {
+    it('then should return 400 bad request http status', async () => {
+        const body = {
+            "title": "UPDATED POST TITLE",
+            "content": "UPDATED POST CONTENT"
+        };
+        const res = await request(app).put(`/post/${exitingPost._id}`)
+            .send(body);
+
+        expect(res.statusCode).toBe(400);
+    });
+});

--- a/tests/__tests__/controllers/posts_controller.test.js
+++ b/tests/__tests__/controllers/posts_controller.test.js
@@ -1,0 +1,21 @@
+const request = require('supertest');
+const app = require('../../../app');
+
+describe('given empty db when http request POST /post', () => {
+    it('then should add posts to the db', async () => {
+        const res = await request(app).post('/post')
+            .send({
+                "sender": "Tal",
+                "title": "Post 2",
+                "content": "HELLO 12345!!"
+            });
+        expect(res.statusCode).toBe(201);
+    });
+});
+
+describe('given db initialized with posts when http request GET /post', () => {
+    it('then should return all posts in the db', async () => {
+        const res = await request(app).get('/post');
+        expect(res.statusCode).toBe(200);
+    });
+});

--- a/tests/jest.config.js
+++ b/tests/jest.config.js
@@ -1,0 +1,18 @@
+// eslint-disable-next-line import/no-commonjs
+module.exports = {
+    testTimeout: 10 * 1000,
+    roots: ['../'],
+    passWithNoTests: true,
+    setupFilesAfterEnv: ['./setup-tests.js'],
+    testMatch: ['**/*.test.js'],
+    collectCoverageFrom: ['../**/*.js', '!../../node_modules/**'],
+    reporters: [
+        'default',
+        ['jest-junit', {
+            outputDirectory: 'tests/reports',
+            outputName: 'junit.xml'
+        }]
+    ],
+    coverageDirectory: '../../tests/reports/coverage',
+    coverageReporters: [['text', { skipFull: true }], 'html', 'cobertura']
+};

--- a/tests/setup-tests.js
+++ b/tests/setup-tests.js
@@ -1,0 +1,56 @@
+const dotenv = require("dotenv");
+const dotenvExpand = require("dotenv-expand");
+dotenvExpand.expand(dotenv.config());
+const mongoose = require('mongoose');
+
+
+/*
+ * Each `__tests__/*.test.js` file is called a test "Suite".
+ * This file configures each test suite.
+ *
+ * - The `global.beforeAll` function configures a global hook to run when a
+ *   suite is being initialzed, and is about to begin running its tests.
+ * - The `global.afterAll` function configures a global hook to run when a
+ *   suite has finished running all of its tests, and is about to close itself.
+ */
+
+
+// Configure environment variables, and allow expand.
+dotenvExpand.expand(dotenv.config());
+
+
+/**
+ * Before each test suite:
+ *
+ * - Generate a new db name.
+ * - Connect to the database.
+ */
+global.beforeAll(() => {
+    const DBNAME = process.env.DB_CONNECTION.split('/')[3].split('?')[0];
+    const newDBNAME = new mongoose.Types.ObjectId().toString();
+
+    const dbConnectionUntilDBNAME =
+    process.env.DB_CONNECTION.substring(0, process.env.DB_CONNECTION.indexOf(DBNAME));
+    const dbConnectionAfterDBNAME =
+    process.env.DB_CONNECTION.substring(process.env.DB_CONNECTION.indexOf(DBNAME) + DBNAME.length);
+    const newDbConnection = dbConnectionUntilDBNAME + newDBNAME + dbConnectionAfterDBNAME;
+    process.env.DB_CONNECTION = newDbConnection;
+
+    console.log(`Connecting to ${process.env.DB_CONNECTION}`)
+    mongoose.connect(process.env.DB_CONNECTION)
+    const db = mongoose.connection;
+    db.on('error', (error) => console.error(error));
+    db.once('open', () => console.log("Connected to DataBase"));
+});
+
+/**
+ * After each test suite:
+ *
+ * - Drop the database.
+ * - Close the connection to the database.
+ */
+global.afterAll(async () => {
+    console.log("Dropping DB...");
+    await mongoose.connection.dropDatabase();
+    await mongoose.connection.close();
+});


### PR DESCRIPTION
Closes #36 

Added unit tests for the controllers endpoints.

The tests are run sequentially, by their order, from top to bottom thanks to the [--runInBand](https://github.com/taljacob2/colman-advanced-web-apps/pull/39/commits/23576cf0772265265e8219d3ae06db556ec03084#) jest parameter. This way we can initialize the database for the specific test suite, and make tests that depend on each other.

### Setup

Make sure you add the new packages with:

```
npm i
```

### Usage

Run the tests with:

```
npm run test
```
