### PR TITLE
Fix tests database flow

### DIFF
--- a/src/tests/setup-tests.ts
+++ b/src/tests/setup-tests.ts
@@ -26,7 +26,7 @@ dotenvExpand.expand(dotenv.config());
  * - Generate a new db name.
  * - Connect to the database.
  */
-global.beforeAll(() => {
+global.beforeAll(async () => {
     const DBNAME = process.env.DB_CONNECTION.split('/')[3].split('?')[0];
     const newDBNAME = "tests";
 
@@ -42,6 +42,9 @@ global.beforeAll(() => {
     const db = mongoose.connection;
     db.on('error', (error) => console.error(error));
     db.once('open', () => console.log("Connected to DataBase"));
+
+    console.log("Dropping DB...");
+    await mongoose.connection.dropDatabase();
 });
 
 /**
@@ -51,7 +54,5 @@ global.beforeAll(() => {
  * - Close the connection to the database.
  */
 global.afterAll(async () => {
-    console.log("Dropping DB...");
-    await mongoose.connection.dropDatabase();
     await mongoose.connection.close();
 });

--- a/src/tests/setup-tests.ts
+++ b/src/tests/setup-tests.ts
@@ -28,7 +28,7 @@ dotenvExpand.expand(dotenv.config());
  */
 global.beforeAll(() => {
     const DBNAME = process.env.DB_CONNECTION.split('/')[3].split('?')[0];
-    const newDBNAME = new mongoose.Types.ObjectId().toString();
+    const newDBNAME = "tests";
 
     const dbConnectionUntilDBNAME =
     process.env.DB_CONNECTION.substring(0, process.env.DB_CONNECTION.indexOf(DBNAME));


### PR DESCRIPTION
- Tests database now has a constant name: `tests`.
- Tests database now drops itself on the `beforeAll` hook, and not in the `afterAll` hook.
